### PR TITLE
fix `queuePreviousMatch` function

### DIFF
--- a/src/Fieldset.ts
+++ b/src/Fieldset.ts
@@ -86,7 +86,7 @@ export type FieldsetCommandResetTimer = {
 }
 
 export type FieldsetCommandQueuePreviousMatch = {
-    cmd: "queuePreviousMatch";
+    cmd: "queuePrevMatch";
 }
 
 export type FieldsetCommandQueueNextMatch = {
@@ -467,7 +467,7 @@ export class Fieldset extends EventEmitter implements FieldsetData {
      **/
     queuePreviousMatch(): Promise<APIResult<void>> {
         return this.send({
-            cmd: "queuePreviousMatch"
+            cmd: "queuePrevMatch"
         });
     };
 


### PR DESCRIPTION
Per the TM API docs, the commend to send over the websocket is `queuePrevMatch` rather than `queuePreviousMatch`.

Not super familiar with ts, but I think I changed what needed to be changed.