### PR TITLE
resolve promise after a successfully sent websocket message

### DIFF
--- a/src/Fieldset.ts
+++ b/src/Fieldset.ts
@@ -135,21 +135,21 @@ export enum FieldsetQueueState {
 
 export type FieldsetMatch =
     | {
-          type: FieldsetActiveMatchType.None;
-      }
+        type: FieldsetActiveMatchType.None;
+    }
     | {
-          type: FieldsetActiveMatchType.Timeout;
-          state: FieldsetQueueState;
-          fieldID: number;
-          active: boolean;
-      }
+        type: FieldsetActiveMatchType.Timeout;
+        state: FieldsetQueueState;
+        fieldID: number;
+        active: boolean;
+    }
     | {
-          type: FieldsetActiveMatchType.Match;
-          state: FieldsetQueueState;
-          match: MatchTuple;
-          fieldID: number;
-          active: boolean;
-      };
+        type: FieldsetActiveMatchType.Match;
+        state: FieldsetQueueState;
+        match: MatchTuple;
+        fieldID: number;
+        active: boolean;
+    };
 
 export type FieldsetState = {
     match: FieldsetMatch;
@@ -410,6 +410,11 @@ export class Fieldset extends EventEmitter implements FieldsetData {
                 } else {
                     try {
                         this.websocket.send(body);
+                        resolve({
+                            success: true,
+                            data: undefined,
+                            cached: false,
+                        });
                     } catch (error) {
                         if (error) {
                             resolve({


### PR DESCRIPTION
While developing a [Bitfocus Compaion](https://bitfocus.io/companion) connector, [companion-module-dwab-tm](https://github.com/Gigantor2131/companion-module-dwab-tm), I discovered the setAudienceDisplay method did not resolve its promise. This resulted in companion logging action time out errors, although the action did successfully complete it never resolved the awaited promise.